### PR TITLE
Correcting the middleware terminate method description

### DIFF
--- a/middleware.md
+++ b/middleware.md
@@ -252,7 +252,7 @@ Middleware parameters may be specified when defining the route by separating the
 
 Sometimes a middleware may need to do some work after the HTTP response has been sent to the browser. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is sent to the browser.
 
-> **Note:** If your web server is not configured to use FastCGI, the `terminate` method on your middleware will be called after the response is prepared to be sent to the browser.
+> **Note:** If your web server is not configured to use FastCGI, the request will run the `terminate` method on your middleware before the HTTP response is sent to the browser. This may result in an increased HTTP response time as it will wait for the code to complete its processing in the `terminate` method.
 
     <?php
 

--- a/middleware.md
+++ b/middleware.md
@@ -250,7 +250,9 @@ Middleware parameters may be specified when defining the route by separating the
 <a name="terminable-middleware"></a>
 ## Terminable Middleware
 
-Sometimes a middleware may need to do some work after the HTTP response has been prepared. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been fully prepared. If you define a `terminate` method on your middleware, it will automatically be called after the response is ready to be sent to the browser.
+Sometimes a middleware may need to do some work after the HTTP response has been sent to the browser. For example, the "session" middleware included with Laravel writes the session data to storage after the response has been sent to the browser. If you define a `terminate` method on your middleware, it will automatically be called after the response is sent to the browser.
+
+> **Note:** If your web server is not configured to use FastCGI, the `terminate` method on your middleware will be called after the response is prepared to be sent to the browser.
 
     <?php
 


### PR DESCRIPTION
As opposed to https://github.com/laravel/docs/commit/984d7851832261261f3fa05badc416ed988a27cf

The previous version is actually true when i tested using nginx 1.16.0 and php 7.1.29 in a Vagrant environment, not php artisan serve.
Production environment will not use php artisan serve

I put a 5 seconds sleep inside the terminate and added a log.
Made a request to the server via AJAX, got a JSON response from the server, after 5 seconds, my log was logged in the laravel log file.